### PR TITLE
Add tablet media query

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,7 @@ label {
 .search-btn {
   background-image: url(./assets/search.svg);
   background-repeat: no-repeat;
-  width: 8%;
+  width: 12%;
   background-color: #343667;
   background-size: 30px 30px;
   background-position: center;
@@ -200,58 +200,77 @@ input::placeholder {
 
 /* media queries */
 
+@media screen and (max-width: 973px) {
+  .starred-btn {
+    font-size: 14px;
+  }
+}
+
+@media screen and (max-width: 800px) {
+
+  body {
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+  }
+
+  form {
+    width: 80%;
+  }
+
+  .search-btn {
+    width: 13%;
+  }
+
+  .card-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .idea-card {
+    margin-bottom: 20px;
+  }
+
+  .star-div {
+    display: none;
+  }
+
+  .title-div {
+    display: grid;
+    grid-template-columns: 1fr 3fr 1fr;
+  }
+
+  .title {
+    text-align: center;
+  }
+
+  .hamburger {
+    display: initial;
+    background-image: url(./assets/menu.svg);
+    background-size: 50px 50px;
+    background-repeat: no-repeat;
+    background-color: #1f1f3d;
+    cursor: pointer;
+    width: 8%;
+    height: 30px;
+    background-position: center;
+    border: none;
+    padding-left: 40px;
+    padding-top: 40px;
+    align-self: flex-start;
+    margin: 20px;
+  }
+
+}
+
 @media screen and (max-width: 500px) {
 
-body {
-  display: flex;
-  flex-flow: column nowrap;
-  justify-content: center;
-}
-
-form {
+  form {
   width: 93%;
-}
+  }
 
-.search-btn {
-  width: 13%;
-}
-
-.card-container {
+  .card-container {
   display: flex;
   flex-direction: column;
-}
-
-.idea-card {
-  margin-bottom: 20px;
-}
-
-.star-div {
-  display: none;
-}
-
-.title-div {
-  display: grid;
-  grid-template-columns: 1fr 3fr 1fr;
-}
-
-.title {
-  text-align: center;
-}
-
-.hamburger {
-  display: initial;
-  background-image: url(./assets/menu.svg);
-  background-size: 50px 50px;
-  background-repeat: no-repeat;
-  background-color: #1f1f3d;
-  width: 8%;
-  height: 30px;
-  background-position: center;
-  border: none;
-  padding-left: 40px;
-  padding-top: 40px;
-  align-self: flex-start;
-  margin: 20px;
-}
-
+  }
 }


### PR DESCRIPTION
Media query set up for tablet size with breakpoints from mobile size to 800px.  Display set to grid so a row of two cards will be set instead of 3 and nav bar moved to top with hamburger.  "Show Starred Ideas" was getting crushed so a small query was set for that.